### PR TITLE
use CoroutineWorker for background patching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
 
     // Compose Destinations
     implementation("io.github.raamcosta.compose-destinations:core:1.6.12-beta")
+    implementation("androidx.work:work-runtime-ktx:2.5.0")
     ksp("io.github.raamcosta.compose-destinations:ksp:1.6.12-beta")
 
     // Accompanist

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
@@ -42,6 +43,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application>
 
+        <service android:name=".ui.screens.mainsubscreens.PatcherWorker"
+            android:isolatedProcess="true"
+            android:foregroundServiceType="" />
+    </application>
 </manifest>

--- a/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
@@ -1,6 +1,7 @@
 package app.revanced.manager.ui.screens.mainsubscreens
 
 import android.app.Application
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -23,23 +24,20 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
 import app.revanced.manager.Global
 import app.revanced.manager.R
 import app.revanced.manager.backend.api.ManagerAPI
-import app.revanced.manager.backend.utils.Aapt
-import app.revanced.manager.backend.utils.aligning.ZipAligner
-import app.revanced.manager.backend.utils.filesystem.ZipFileSystemUtils
-import app.revanced.manager.backend.utils.signing.Signer
 import app.revanced.manager.settings
 import app.revanced.manager.ui.Resource
 import app.revanced.manager.ui.components.FloatingActionButton
 import app.revanced.manager.ui.screens.destinations.AppSelectorScreenDestination
 import app.revanced.manager.ui.screens.destinations.PatchesSelectorScreenDestination
-import app.revanced.patcher.Patcher
-import app.revanced.patcher.PatcherOptions
 import app.revanced.patcher.data.Data
 import app.revanced.patcher.extensions.PatchExtensions.compatiblePackages
-import app.revanced.patcher.extensions.PatchExtensions.patchName
 import app.revanced.patcher.patch.Patch
 import app.revanced.patcher.util.patch.implementation.DexPatchBundle
 import com.ramcosta.composedestinations.annotation.Destination
@@ -51,6 +49,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.util.*
 
+
 private const val tag = "PatcherScreen"
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -59,7 +58,7 @@ private const val tag = "PatcherScreen"
 @Composable
 fun PatcherSubscreen(
     navigator: NavController,
-    vm: PatcherViewModel = viewModel(LocalContext.current as ComponentActivity)
+    vm: PatcherViewModel = viewModel(LocalContext.current as ComponentActivity),
 ) {
     val selectedAppPackage by vm.selectedAppPackage
     val hasAppSelected = selectedAppPackage.isPresent
@@ -132,18 +131,16 @@ fun PatcherSubscreen(
 
 data class PatchClass(
     val patch: Class<out Patch<Data>>,
-    val unsupported: Boolean
+    val unsupported: Boolean,
 )
 
 class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
-    private val aaptPath = Aapt.binary(app).absolutePath
     private val bundleCacheDir = app.filesDir.resolve("bundle-cache").also { it.mkdirs() }
-    private val frameworkPath = app.filesDir.resolve("framework").also { it.mkdirs() }.absolutePath
-    private val integrationsCacheDir = app.filesDir.resolve("integrations-cache").also { it.mkdirs() }
 
     val selectedAppPackage = mutableStateOf(Optional.empty<String>())
     private val selectedPatches = mutableStateListOf<String>()
     val patches = mutableStateOf<Resource<List<Class<out Patch<Data>>>>>(Resource.Loading)
+    lateinit var patchBundleFile: String
 
     init {
         loadPatches()
@@ -173,10 +170,7 @@ class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
         return !selectedPatches.isEmpty()
     }
 
-    private fun findPatchesByIds(ids: Iterable<String>): List<Class<out Patch<Data>>> {
-        val (patches) = patches.value as? Resource.Success ?: return listOf()
-        return patches.filter { patch -> ids.any { it == patch.patchName } }
-    }
+
 
     private fun getSelectedPackageInfo() =
         if (selectedAppPackage.value.isPresent)
@@ -214,18 +208,10 @@ class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private suspend fun downloadIntegrations(workdir: File): File {
-        return try {
-            val (_, out) = ManagerAPI.downloadIntegrations(workdir, this.app.baseContext.settings.data.map { pref -> pref.get(stringPreferencesKey("integrations")) ?: Global.ghIntegrations }.first())
-            out
-        } catch (e: Exception) {
-            throw Exception("Failed to download integrations", e)
-        }
-    }
-
     private fun loadPatches() = viewModelScope.launch {
         try {
             val file = downloadDefaultPatchBundle(bundleCacheDir)
+            patchBundleFile=file.absolutePath
             loadPatches0(file.absolutePath)
         } catch (e: Exception) {
             Log.e(tag, "An error occurred while loading patches", e)
@@ -244,86 +230,18 @@ class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
         patches.value = Resource.Success(patchClasses)
     }
 
-    private fun createWorkDir(): File {
-        return app.filesDir.resolve("tmp-${System.currentTimeMillis()}").also { it.mkdirs() }
-    }
-
     fun startPatcher() {
-        val tag = "Patcher"
-
-        viewModelScope.launch {
-            Log.d(tag, "Checking prerequisites")
-            val info = getSelectedPackageInfo()?.applicationInfo ?: return@launch
-            val patches = findPatchesByIds(selectedPatches)
-            if (patches.isEmpty()) return@launch
-            val integrations = downloadIntegrations(integrationsCacheDir)
-
-            Log.d(tag, "Creating directories")
-            val workdir = createWorkDir()
-            val inputFile = File(workdir.parentFile!!, "base.apk")
-            val patchedFile = File(workdir, "patched.apk")
-            val alignedFile = File(workdir, "aligned.apk")
-            val outputFile = File(workdir, "out.apk")
-            val cacheDirectory = workdir.resolve("cache")
-            val buildDirectory = cacheDirectory.resolve("build")
-
-            try {
-//                Log.d(tag, "Copying base.apk from ${info.packageName}")
-//                withContext(Dispatchers.IO) {
-//                    Files.copy(
-//                        File(info.publicSourceDir).toPath(),
-//                        inputFile.toPath(),
-//                        StandardCopyOption.REPLACE_EXISTING
-//                    )
-//                }
-
-                Log.d(tag, "Creating patcher")
-                val patcher = Patcher(
-                    PatcherOptions(
-                        inputFile,
-                        cacheDirectory.absolutePath,
-                        patchResources = true,
-                        aaptPath = aaptPath,
-                        frameworkFolderLocation = frameworkPath
+        WorkManager
+            .getInstance(app)
+            .enqueue(
+                OneTimeWorkRequest.Builder(PatcherWorker::class.java)
+                    .setInputData(
+                        androidx.work.Data.Builder()
+                            .putStringArray("selectedPatches",selectedPatches.toTypedArray())
+                            .putString("patchBundleFile",patchBundleFile)
+                            .build()
                     )
-                )
-
-                Log.d(tag, "Merging integrations")
-                patcher.addFiles(listOf(integrations)) {}
-
-                Log.d(tag, "Adding ${patches.size} patch(es)")
-                patcher.addPatches(patches)
-
-                Log.d(tag, "Applying patches")
-                patcher.applyPatches().forEach { (patch, result) ->
-                    if (result.isSuccess) {
-                        Log.i(tag, "[success] $patch")
-                        return@forEach
-                    }
-                    Log.e(tag, "[error] $patch:", result.exceptionOrNull()!!)
-                }
-
-                Log.d(tag, "Saving file")
-                val result = patcher.save()
-                ZipFileSystemUtils(result.resourceFile!!, patchedFile).use { fs ->
-                    result.dexFiles.forEach { fs.write(it.name, it.dexFileInputStream.readBytes()) }
-                    fs.writeInput()
-                    fs.uncompress(*result.doNotCompress!!.toTypedArray())
-                }
-
-                Log.d(tag, "Aligning apk")
-                ZipAligner.align(patchedFile, alignedFile)
-                Log.d(tag, "Signing apk")
-                Signer("ReVanced", "s3cur3p@ssw0rd").signApk(alignedFile, outputFile)
-
-                // TODO: install apk!
-                Log.d(tag, "Installing apk")
-            } catch (e: Exception) {
-                Log.e(tag, "Error while patching", e)
-            }
-
-            Log.d(tag, "Deleting workdir")
-            //workdir.deleteRecursively()
-        }
+                    .build()
+            )
     }
 }

--- a/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherWorker.kt
@@ -1,0 +1,230 @@
+package app.revanced.manager.ui.screens.mainsubscreens
+
+import android.app.*
+import android.content.Context
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.net.Uri
+import android.os.IBinder
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import app.revanced.manager.Global
+import app.revanced.manager.R
+import app.revanced.manager.backend.api.ManagerAPI
+import app.revanced.manager.backend.utils.Aapt
+import app.revanced.manager.backend.utils.aligning.ZipAligner
+import app.revanced.manager.backend.utils.filesystem.ZipFileSystemUtils
+import app.revanced.manager.backend.utils.signing.Signer
+import app.revanced.manager.settings
+import app.revanced.manager.ui.Resource
+import app.revanced.patcher.Patcher
+import app.revanced.patcher.PatcherOptions
+import app.revanced.patcher.data.Data
+import app.revanced.patcher.extensions.PatchExtensions.patchName
+import app.revanced.patcher.patch.Patch
+import app.revanced.patcher.util.patch.implementation.DexPatchBundle
+import dalvik.system.DexClassLoader
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.lang.IllegalArgumentException
+
+class PatcherWorker(context: Context, parameters: WorkerParameters) :
+    CoroutineWorker(context, parameters) {
+    val patches = mutableStateOf<Resource<List<Class<out Patch<Data>>>>>(Resource.Loading)
+    val tag = "Patcher"
+
+    override suspend fun doWork(): Result {
+        val selectedPatches = inputData.getStringArray("selectedPatches")
+            ?: throw IllegalArgumentException("selectedPatches is missing")
+        val patchBundleFile = inputData.getString("patchBundleFile")
+            ?: throw IllegalArgumentException("patchBundleFile is missing")
+
+        val notificationIntent = Intent(applicationContext, PatcherWorker::class.java)
+        val pendingIntent: PendingIntent =
+            PendingIntent.getActivity(
+                applicationContext,
+                0,
+                notificationIntent,
+                PendingIntent.FLAG_IMMUTABLE
+            )
+        val channel =
+            NotificationChannel(
+                "revanced-patcher-patching",
+                "Patching",
+                NotificationManager.IMPORTANCE_LOW
+            )
+        val notificationManager =
+            ContextCompat.getSystemService(applicationContext, NotificationManager::class.java)
+        notificationManager!!.createNotificationChannel(channel)
+        val notification: Notification = Notification.Builder(applicationContext, channel.id)
+            .setContentTitle(applicationContext.getText(R.string.patcher_notification_title))
+            .setContentText(applicationContext.getText(R.string.patcher_notification_message))
+            .setLargeIcon(Icon.createWithResource(applicationContext, R.drawable.manager))
+            .setSmallIcon(Icon.createWithResource(applicationContext, R.drawable.manager))
+            .setContentIntent(pendingIntent)
+            .build()
+
+        setForeground(ForegroundInfo(1, notification))
+
+        runPatcher(selectedPatches.toList(), patchBundleFile)
+        return Result.success()
+    }
+
+    private suspend fun runPatcher(selectedPatches: List<String>, patchBundleFile: String): Boolean {
+
+        val aaptPath = Aapt.binary(applicationContext).absolutePath
+        val frameworkPath =
+            applicationContext.filesDir.resolve("framework").also { it.mkdirs() }.absolutePath
+        val integrationsCacheDir =
+            applicationContext.filesDir.resolve("integrations-cache").also { it.mkdirs() }
+
+        loadPatches(patchBundleFile)
+        Log.d(tag, "Checking prerequisites")
+        val patches = findPatchesByIds(selectedPatches)
+        if (patches.isEmpty()) return true
+        val integrations = downloadIntegrations(integrationsCacheDir)
+
+        Log.d(tag, "Creating directories")
+        val workdir = createWorkDir()
+        val inputFile = File(workdir.parentFile!!, "base.apk")
+        val patchedFile = File(workdir, "patched.apk")
+        val alignedFile = File(workdir, "aligned.apk")
+        val outputFile = File(workdir, "out.apk")
+        val cacheDirectory = workdir.resolve("cache")
+
+        try {
+            //                Log.d(tag, "Copying base.apk from ${info.packageName}")
+            //                withContext(Dispatchers.IO) {
+            //                    Files.copy(
+            //                        File(info.publicSourceDir).toPath(),
+            //                        inputFile.toPath(),
+            //                        StandardCopyOption.REPLACE_EXISTING
+            //                    )
+            //                }
+
+            Log.d(tag, "Creating patcher")
+            val patcher = Patcher(
+                PatcherOptions(
+                    inputFile,
+                    cacheDirectory.absolutePath,
+                    patchResources = true,
+                    aaptPath = aaptPath,
+                    frameworkFolderLocation = frameworkPath,
+                    logger = object : app.revanced.patcher.logging.Logger {
+                        override fun error(msg: String) {
+                            Log.e(tag, msg)
+                        }
+
+                        override fun warn(msg: String) {
+                            Log.w(tag, msg)
+                        }
+
+                        override fun info(msg: String) {
+                            Log.i(tag, msg)
+                        }
+
+                        override fun trace(msg: String) {
+                            Log.v(tag, msg)
+                        }
+                    }
+                )
+            )
+
+            Log.d(tag, "Merging integrations")//TODO add again
+            patcher.addFiles(listOf(integrations)) {}
+
+            Log.d(tag, "Adding ${patches.size} patch(es)")
+            patcher.addPatches(patches)
+
+            Log.d(tag, "Applying patches")
+            patcher.applyPatches().forEach { (patch, result) ->
+                if (result.isSuccess) {
+                    Log.i(tag, "[success] $patch")
+                    return@forEach
+                }
+                Log.e(tag, "[error] $patch:", result.exceptionOrNull()!!)
+            }
+
+            Log.d(tag, "Saving file")
+            val result = patcher.save()
+            ZipFileSystemUtils(result.resourceFile!!, patchedFile).use { fs ->
+                result.dexFiles.forEach { fs.write(it.name, it.dexFileInputStream.readBytes()) }
+                fs.writeInput()
+                fs.uncompress(*result.doNotCompress!!.toTypedArray())
+            }
+
+            Log.d(tag, "Aligning apk")
+            ZipAligner.align(patchedFile, alignedFile)
+            Log.d(tag, "Signing apk")
+            Signer("ReVanced", "s3cur3p@ssw0rd").signApk(alignedFile, outputFile)
+            Log.d(tag, "Installing apk ${outputFile.absolutePath}")
+            install(outputFile)
+        } catch (e: Exception) {
+            Log.e(tag, "Error while patching", e)
+        }
+
+        Log.d(tag, "Deleting workdir")
+        //workdir.deleteRecursively()
+
+        return false
+    }
+
+    private fun install(apk: File) {
+        val intent = Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(
+            Uri.fromFile(apk), "application/vnd.android.package-archive"
+        );
+        applicationContext.startActivity(intent);
+    }
+
+    private fun createWorkDir(): File {
+        return applicationContext.filesDir.resolve("tmp-${System.currentTimeMillis()}")
+            .also { it.mkdirs() }
+    }
+
+    private fun findPatchesByIds(ids: Iterable<String>): List<Class<out Patch<Data>>> {
+        val (patches) = patches.value as? Resource.Success ?: return listOf()
+        return patches.filter { patch -> ids.any { it == patch.patchName } }
+    }
+
+    private suspend fun downloadIntegrations(workdir: File): File {
+        return try {
+            val (_, out) = ManagerAPI.downloadIntegrations(
+                workdir,
+                applicationContext.settings.data.map { pref ->
+                    pref.get(stringPreferencesKey("integrations")) ?: Global.ghIntegrations
+                }.first()
+            )
+            out
+        } catch (e: Exception) {
+            throw Exception("Failed to download integrations", e)
+        }
+    }
+
+    private fun loadPatches(patchBundleFile: String) {
+        try {
+            loadPatches0(patchBundleFile)
+        } catch (e: Exception) {
+            Log.e(tag, "An error occurred while loading patches", e)
+        }
+    }
+
+    private fun loadPatches0(path: String) {
+        val patchClasses = DexPatchBundle(
+            path, DexClassLoader(
+                path,
+                applicationContext.codeCacheDir.absolutePath,
+                null,
+                javaClass.classLoader
+            )
+        ).loadPatches()
+        patches.value = Resource.Success(patchClasses)
+    }
+}

--- a/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherWorker.kt
@@ -1,11 +1,13 @@
 package app.revanced.manager.ui.screens.mainsubscreens
 
-import android.app.*
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Icon
 import android.net.Uri
-import android.os.IBinder
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.content.ContextCompat
@@ -31,9 +33,7 @@ import app.revanced.patcher.util.patch.implementation.DexPatchBundle
 import dalvik.system.DexClassLoader
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import java.io.File
-import java.lang.IllegalArgumentException
 
 class PatcherWorker(context: Context, parameters: WorkerParameters) :
     CoroutineWorker(context, parameters) {
@@ -164,8 +164,7 @@ class PatcherWorker(context: Context, parameters: WorkerParameters) :
             ZipAligner.align(patchedFile, alignedFile)
             Log.d(tag, "Signing apk")
             Signer("ReVanced", "s3cur3p@ssw0rd").signApk(alignedFile, outputFile)
-            Log.d(tag, "Installing apk ${outputFile.absolutePath}")
-            install(outputFile)
+            Log.i(tag,"Successfully patched into $outputFile")
         } catch (e: Exception) {
             Log.e(tag, "Error while patching", e)
         }
@@ -176,13 +175,13 @@ class PatcherWorker(context: Context, parameters: WorkerParameters) :
         return false
     }
 
-    private fun install(apk: File) {
-        val intent = Intent(Intent.ACTION_VIEW);
-        intent.setDataAndType(
-            Uri.fromFile(apk), "application/vnd.android.package-archive"
-        );
-        applicationContext.startActivity(intent);
-    }
+    //private fun installNonRoot(apk: File) {
+    //    val intent = Intent(Intent.ACTION_VIEW);
+    //    intent.setDataAndType(
+    //        Uri.fromFile(apk), "application/vnd.android.package-archive"
+    //    );
+    //    applicationContext.startActivity(intent);
+    //}
 
     private fun createWorkDir(): File {
         return applicationContext.filesDir.resolve("tmp-${System.currentTimeMillis()}")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,6 @@
     <string name="version_info">Version info</string>
     <string name="unsupported_version">Unsupported version</string>
     <string name="compatible_versions">Compatible app versions</string>
+    <string name="patcher_notification_title">Patching</string>
+    <string name="patcher_notification_message">ReVanced Manager is patching</string>
 </resources>


### PR DESCRIPTION
Currently, ReVanced Manager uses the `viewModelScope` in order to do patching in `PatcherSubscreen.startPatcher`.
While parts of the patching use coroutines, not all do. This would result in the whole `viewModelScope` being blocked when Androlib or other blocking functions (that is not using coroutines) are invoked.

Furthermore, this is a long-lasting operation. This means that the whole patching process is interrupted as soon as the user opens another app and Android decides to kill the app.

This PR moves patching to a `CoroutineWorker` so that patching is possible in a background process without needing to worry about Android destroying the activity.