### PR TITLE
fix: make PatcherWorker not restart

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screens/mainsubscreens/PatcherSubscreen.kt
@@ -24,10 +24,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import androidx.work.OneTimeWorkRequest
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.WorkerParameters
+import androidx.work.*
 import app.revanced.manager.Global
 import app.revanced.manager.R
 import app.revanced.manager.backend.api.ManagerAPI
@@ -233,7 +230,9 @@ class PatcherViewModel(val app: Application) : AndroidViewModel(app) {
     fun startPatcher() {
         WorkManager
             .getInstance(app)
-            .enqueue(
+            .enqueueUniqueWork(
+                "patching",
+                ExistingWorkPolicy.REPLACE,
                 OneTimeWorkRequest.Builder(PatcherWorker::class.java)
                     .setInputData(
                         androidx.work.Data.Builder()


### PR DESCRIPTION
Currently, patching restarts when the Manager crashes (or is stopped completely) and restarts (even when the phone restarts).
This Pull Request changes this behaviour to fail patching instead of restarting it.
Furthermore, it makes sure that patching is cancelled before patching again (when pressing the `Patch` button multiple times).