### PR TITLE
feat: copy APK from selected app

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,6 @@
     <string name="compatible_versions">Compatible app versions</string>
     <string name="patcher_notification_title">Patching</string>
     <string name="patcher_notification_message">ReVanced Manager is patching</string>
+    <string name="storage_permission_missing">Permission for accessing files is missing.</string>
+    <string name="patching_succeeded">Patching was successful. Please find the patched APK in your Downloads directory.</string>
 </resources>


### PR DESCRIPTION
This PR makes a copy of the `base.apk` from the selected app before patching. That is then used for patching.

Furthermore, after patching, it copies the patched APK to the downloads directory and shows a toast when this is finished.

To be done: Logic for requesting the permission for accessing the downloads directory